### PR TITLE
Query market by mints

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -161,6 +161,29 @@ export class Market {
     return _MARKET_STATE_LAYOUT_V2;
   }
 
+  static async findAddressByMints(
+    connection: Connection,
+    baseMintAddress: PublicKey,
+    quoteMintAddress: PublicKey,
+    programId: PublicKey,
+  ) {
+    const filters = [
+      {
+        memcmp: {
+          offset: this.getLayout(programId).offsetOf('baseMint'),
+          bytes: baseMintAddress.toBase58(),
+        },
+      },
+      {
+        memcmp: {
+          offset: Market.getLayout(programId).offsetOf('quoteMint'),
+          bytes: quoteMintAddress.toBase58(),
+        },
+      },
+    ];
+    return getFilteredProgramAccounts(connection, programId, filters);
+  }
+
   static async load(
     connection: Connection,
     address: PublicKey,

--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -161,7 +161,7 @@ export class Market {
     return _MARKET_STATE_LAYOUT_V2;
   }
 
-  static async findAddressByMints(
+  static async findAccountsByMints(
     connection: Connection,
     baseMintAddress: PublicKey,
     quoteMintAddress: PublicKey,


### PR DESCRIPTION
I find this method helpful to query Serum markets from the Base Asset Mint address and the Quote Asset Mint address. Opening a PR in case others in the community could find use for it. 