### PR TITLE
package.json - path fix in "types" property

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.12",
   "description": "Serum Swap",
   "main": "lib/index.js",
-  "types": "lib/src/index.d.ts",
+  "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixed the path in the `types` property of `package.json` so that VS Code is able to properly resolve the package when imported