### PR TITLE
Adds ROPE token mint and ROPE/USDC market

### DIFF
--- a/packages/serum/src/markets.json
+++ b/packages/serum/src/markets.json
@@ -1210,5 +1210,11 @@
     "address": "7MpMwArporUHEGW7quUpkPZp5L5cHPs9eKUfKCdaPHq2",
     "deprecated": false,
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+  },
+  {
+    "name": "ROPE/USDC",
+    "address": "7TbVP3sm8quUkaFmyeBoKBNhXMTXSfrEPniR9CQvr2Yr",
+    "deprecated": false,
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   }
 ]

--- a/packages/serum/src/token-mints.json
+++ b/packages/serum/src/token-mints.json
@@ -154,5 +154,9 @@
   {
     "address": "6ry4WBDvAwAnrYJVv6MCog4J8zx6S3cPgSqnTsDZ73AR",
     "name": "TRYB"
+  },
+  {
+    "address": "8PMHT4swUMtBzgHnh5U564N5sjPSiUz2cjEQzFnnP1Fo",
+    "name": "ROPE"
   }
 ]


### PR DESCRIPTION
This change adds the $ROPE token mint to the mint list and the ROPE/USDC market to the markets list.

$ROPE is a full-scale decentralized ecosystem that brings the well-known "market volatility index" to the crypto market.

Token Address: 8PMHT4swUMtBzgHnh5U564N5sjPSiUz2cjEQzFnnP1Fo
Token Name: Rope Token
Token Symbol: ROPE
Link to the official homepage of token: https://ropesolana.com/