### PR TITLE
remove wrong market OXY/USDT

### DIFF
--- a/packages/serum/src/markets.json
+++ b/packages/serum/src/markets.json
@@ -1194,12 +1194,6 @@
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
-    "name": "OXY/USDT",
-    "address": "HdBhZrnrxpje39ggXnTb6WuTWVvj5YKcSHwYGQCRsVj",
-    "deprecated": false,
-    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
-  },
-  {
     "name": "OXY/USDC",
     "address": "GZ3WBFsqntmERPwumFEYgrX2B7J7G11MzNZAy7Hje27X",
     "deprecated": false,


### PR DESCRIPTION
Please remove wrong market OXY/USDT because it is market for OXY/WUSDT pair. And there is the OXY/WUSDT market in list (please, check previous element in array).