### PR TITLE
swap: Complete example

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -1,4 +1,4 @@
-# Serum Swap
+# Swap
 
 [![Build Status](https://travis-ci.com/project-serum/serum-ts.svg?branch=master)](https://travis-ci.com/project-serum/serum-ts)
 [![npm (scoped)](https://img.shields.io/npm/v/@project-serum/swap)](https://www.npmjs.com/package/@project-serum/swap)
@@ -14,13 +14,13 @@ The Solana program can be found [here](https://github.com/project-serum/swap).
 Using npm:
 
 ```
-npm install @solana/web3.js @project-serum/swap
+npm install @project-serum/swap
 ```
 
 Using yarn:
 
 ```
-yarn add @solana/web3.js @project-serum/swap
+yarn add @project-serum/swap
 ```
 
 ## API Reference

--- a/packages/swap/examples/swap.js
+++ b/packages/swap/examples/swap.js
@@ -37,8 +37,7 @@ async function main() {
     toMint: WBTC,
     amount: toNative(1),
   });
-		console.log('estimate', estimatedBtc.toNumber());
-/*
+
   // Swaps SRM -> USDC on the Serum orderbook. If the resulting USDC is
   // has greater than a 1% error from the estimate, then fails.
   const usdcSwapTx = await client.swap({
@@ -47,6 +46,10 @@ async function main() {
     amount: toNative(1),
     minExpectedSwapAmount: estimatedUsdc.mul(new BN(99)).div(new BN(100)),
   });
+
+/*
+		console.log('estimated usdc', estimatedUsdc.toNumber()/10**6);
+		console.log('estimate', estimatedBtc.toNumber());
 
   // Uses the default minExpectedSwapAmount calculation.
   const usdcSwapTxDefault = await client.swap({

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-serum/swap",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Client for swapping on the Serum DEX",
   "license": "MIT",
   "repository": "project-serum/serum-ts",


### PR DESCRIPTION
Followup for https://github.com/project-serum/serum-ts/pull/98

TODO:

* switch `swapIxs` to return an array of `Transaction` objects instead of instructions and use `Provider.sendAll` to get around transaction size limits