### PR TITLE
Reduce TX size by using account deduplication

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-serum/swap",
-  "version": "0.1.0-alpha.31",
+  "version": "0.1.0-alpha.32",
   "description": "Client for swapping on the Serum DEX",
   "license": "MIT",
   "repository": "project-serum/serum-ts",
@@ -45,14 +45,16 @@
   },
   "dependencies": {
     "@project-serum/serum": "^0.13.34",
-    "@solana/spl-token": "^0.1.3",
+    "@solana/web3.js": "^1.24.0",
+    "@solana/spl-token": "^0.1.6",
+    "@solana/spl-token-registry": "^0.2.214",
     "base64-js": "^1.5.1",
     "bn.js": "^5.1.2"
   },
   "peerDependencies": {
     "@project-serum/anchor": "^0.7.0",
-    "@solana/spl-token-registry": "^0.2.102",
-    "@solana/web3.js": "^1.17.0"
+    "@solana/spl-token-registry": "^0.2.214",
+    "@solana/web3.js": "^1.24.0"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -359,7 +359,7 @@ export class Swap {
           authority: this.program.provider.wallet.publicKey,
           dexProgram: DEX_PID,
           tokenProgram: TOKEN_PROGRAM_ID,
-          rent: SYSVAR_RENT_PUBKEY,
+          rent: TOKEN_PROGRAM_ID,
         },
         remainingAccounts: referral && [
           { pubkey: referral, isWritable: true, isSigner: false },
@@ -622,7 +622,7 @@ export class Swap {
           authority: this.program.provider.wallet.publicKey,
           dexProgram: DEX_PID,
           tokenProgram: TOKEN_PROGRAM_ID,
-          rent: SYSVAR_RENT_PUBKEY,
+          rent: TOKEN_PROGRAM_ID,
         },
         remainingAccounts: referral && [
           { pubkey: referral, isWritable: true, isSigner: false },


### PR DESCRIPTION
DEX now uses dynamic sysvars (https://github.com/project-serum/serum-dex/pull/155) for rent so no need to pass in that account. Reuse the token program ID so that it is deduped and we save 32 bytes. This should resolve the occasional swap failure for some users that receive the tx too large error:
![image](https://user-images.githubusercontent.com/20787054/129784128-b7cbd546-ce04-450f-96c8-24794e2b2024.png)

In local testing I also needed to change the package dependencies and took the liberty of updating a couple of them.
