### PR TITLE
Add Cyclos (CYS) token mint in @project-serum/serum

### DIFF
--- a/packages/serum/package.json
+++ b/packages/serum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-serum/serum",
-  "version": "0.13.59",
+  "version": "0.13.60",
   "description": "Library for interacting with the serum dex",
   "license": "MIT",
   "repository": "project-serum/serum-ts",

--- a/packages/serum/src/token-mints.json
+++ b/packages/serum/src/token-mints.json
@@ -168,6 +168,10 @@
     "name": "SNY"
   },
   {
+    "address": "BRLsMczKuaR5w9vSubF4j8HwEGGprVAyyVgS4EX7DKEg",
+    "name": "CYS"
+  },
+  {
     "address": "SLRSSpSLUTP7okbCUBYStWCo1vUgyt775faPqz8HUMr",
     "name": "SLRS"
   },


### PR DESCRIPTION
Making a new PR because I missed adding to `token-mints.json` last time. We're self-hosting Serum's DEX UI; our token name will be displayed as 'UNKNOWN' without this update.

On a side note, token and market data in Solana is siloed in different repos. This will not scale as the ecosystem grows
1. [Official token list](https://github.com/solana-labs/token-list)
2. `token-mints.json` in `@project-serum/serum`
3. `markets.json` in `@project-serum/serum`
4. `mainnet-beta.json` in `@project-serum/tokens`