### PR TITLE
fix: bn overflow error

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -1541,10 +1541,12 @@ function getPriceFromKey(key) {
 }
 
 function divideBnToNumber(numerator: BN, denominator: BN): number {
-  const quotient = numerator.div(denominator).toNumber();
+  const quotient = numerator.div(denominator);
   const rem = numerator.umod(denominator);
   const gcd = rem.gcd(denominator);
-  return quotient + rem.div(gcd).toNumber() / denominator.div(gcd).toNumber();
+  return Number(
+    quotient.add(rem.div(gcd).div(denominator.div(gcd))).toString(),
+  );
 }
 
 const MINT_LAYOUT = struct([blob(44), u8('decimals'), blob(37)]);


### PR DESCRIPTION
most of the time calling `toNumber()` would result in `Number can only safely store up to 53 bits`, workaround is to just call `toString()` into `Number()`