### PR TITLE
[Serum] Populate seqNum on fills and implement loadFillsSince

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -15,7 +15,11 @@ import {
   TransactionInstruction,
   TransactionSignature,
 } from '@solana/web3.js';
-import { decodeEventQueue, decodeRequestQueue } from './queue';
+import {
+  decodeEventQueue,
+  decodeEventsSince,
+  decodeRequestQueue,
+} from './queue';
 import { Buffer } from 'buffer';
 import { getFeeTier, supportsSrmFeeDiscounts } from './fees';
 import {
@@ -1111,6 +1115,18 @@ export class Market {
       await connection.getAccountInfo(this._decoded.eventQueue),
     );
     const events = decodeEventQueue(data, limit);
+    return this.parseFillEvents(events);
+  }
+
+  async loadFillsSince(connection: Connection, lastSeqNum: number) {
+    const { data } = throwIfNull(
+      await connection.getAccountInfo(this._decoded.eventQueue),
+    );
+    const events = decodeEventsSince(data, lastSeqNum);
+    return this.parseFillEvents(events);
+  }
+
+  parseFillEvents(events) {
     return events
       .filter(
         (event) => event.eventFlags.fill && event.nativeQuantityPaid.gtn(0),

--- a/packages/serum/src/queue.ts
+++ b/packages/serum/src/queue.ts
@@ -170,6 +170,12 @@ export function decodeEventQueue(buffer: Buffer, history?: number): Event[] {
   if (!header.accountFlags.initialized || !header.accountFlags.eventQueue) {
     throw new Error('Invalid events queue');
   }
+  const modulo32Uint = 0x100000000;
+  let startSeqNum = header.seqNum + header.count - nodes.length;
+  for (const [i, node] of nodes.entries()) {
+    // seqNum itself may have u32 overflow in this span of `nodes`
+    node.seqNum = (startSeqNum + i + modulo32Uint) % modulo32Uint;
+  }
   return nodes;
 }
 


### PR DESCRIPTION
Thank you for implementing this client library for Serum! I really appreciate the open-source efforts to make the Dex accessible, and I'd like to make my own contribution.

# Description

This PR makes two changes:
1. Populates the `seqNum` on the `Event` type in `decodeEventQueue`
2. Implements a new function `loadFillsSince`

# Why

It appears based on `git blame` that `seqNum` was added after `decodeEventQueue`, and `decodeEventQueue` was never updated.

I think it would be useful to populate the `seqNum` given it is available as a field, and there isn't a way to uniquely determine whether you've processed a `Fill` without it.

I also implemented an additional `loadFillsSince` API function, since there is already functionality to `decodeEventsSince`, and I think it would useful to be able to `loadFillsSince` a given `seqNum`


# Testing
I manually against the Serum Validator node: 
https://solana-api.projectserum.com

Goal was to test that the `seqNum` is calculated correctly, being careful to make sure it handles the `u32overflow` case.

Here is a sample test output. Notice that head `seqNum` is `26178226`, `count` is `4`, user-requested `limit` is `5`. 

Doing the logic and calculating the expected case by hand:

Header seqNum: `26178226`
Count: `4`
Ending seqNum: `26178226 + 4 - 1 = 26178229`
Starting seqNum: `endSeqNum - limit = 26178225`

The test output below correctly indicates the modified `decodeEventQueue` returns `5 fill events` with the `seqNum` starting from `26178225`:

```javascript
{
  head: 967,
  count: 4,
  seqNum: 26178226
}
// decodeEvents: requested limit 5


[
  {
    orderId: <BN: 6c0d1fffffffffefbe0a9>,
    seqNum: 26178225
  },
  {
    orderId: <BN: 5b706fffffffffefbe0af>,
    seqNum: 26178226
  },
  {
    orderId: <BN: 4f414fffffffffefbe0b0>,
    seqNum: 26178227
  },
  {
    orderId: <BN: 630defffffffffefbe0b3>,
    seqNum: 26178228
  },
  {
    orderId: <BN: 82fc00000000001041f4a>,
    seqNum: 26178229
  }
]
```





