### PR TITLE
rename sollet-wrapped assets and add wormhole-wrapped assets to token/market lists

### DIFF
--- a/packages/serum/src/markets.json
+++ b/packages/serum/src/markets.json
@@ -2,31 +2,31 @@
   {
     "address": "B37pZmwrwXHjpgvd9hHDAx1yeDsNevTnbbrN9W12BoGK",
     "deprecated": true,
-    "name": "ALEPH/WUSDC",
+    "name": "soALEPH/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "CAgAeMD7quTdnr6RPa7JySQpjf3irAmefYNdTb6anemq",
     "deprecated": true,
-    "name": "BTC/WUSDC",
+    "name": "BTC/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "ASKiV944nKg1W9vsf7hf3fTsjawK6DwLwrnB2LH9n61c",
     "deprecated": true,
-    "name": "ETH/WUSDC",
+    "name": "soETH/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "Cdp72gDcYMCLLk3aDkPxjeiirKoFqK38ECm8Ywvk94Wi",
     "deprecated": true,
-    "name": "SOL/WUSDC",
+    "name": "SOL/soUSDC",
     "programId": "BJ3jrUzddfuSrZHXSCxMUUQsjKEyLmuuyZebkcaFp2fg"
   },
   {
     "address": "68J6nkWToik6oM9rTatKSR5ibVSykAtzftBUEAvpRsys",
     "deprecated": true,
-    "name": "SRM/WUSDC",
+    "name": "SRM/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
@@ -38,199 +38,199 @@
   {
     "address": "9wDmxsfwaDb2ysmZpBLzxKzoWrF1zHzBN7PV5EmJe19R",
     "deprecated": true,
-    "name": "SUSHI/WUSDC",
+    "name": "soSUSHI/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "GbQSffne1NcJbS4jsewZEpRGYVR4RNnuVUN8Ht6vAGb6",
     "deprecated": true,
-    "name": "SXP/WUSDC",
+    "name": "soSXP/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "7kgkDyW7dmyMeP8KFXzbcUZz1R2WHsovDZ7n3ihZuNDS",
     "deprecated": true,
-    "name": "MSRM/WUSDC",
+    "name": "MSRM/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "FZqrBXz7ADGsmDf1TM9YgysPUfvtG8rJiNUrqDpHc9Au",
     "deprecated": true,
-    "name": "FTT/WUSDC",
+    "name": "soFTT/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "FJg9FUtbN3fg3YFbMCFiZKjGh5Bn4gtzxZmtxFzmz9kT",
     "deprecated": true,
-    "name": "YFI/WUSDC",
+    "name": "soYFI/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "7GZ59DMgJ7D6dfoJTpszPayTRyua9jwcaGJXaRMMF1my",
     "deprecated": true,
-    "name": "LINK/WUSDC",
+    "name": "soLINK/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "uPNcBgFhrLW3FtvyYYbBUi53BBEQf9e4NPgwxaLu5Hn",
     "deprecated": true,
-    "name": "HGET/WUSDC",
+    "name": "soHGET/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "3puWJFZyCso14EdxhywjD7xqyTarpsULx483mzvqxQRW",
     "deprecated": true,
-    "name": "CREAM/WUSDC",
+    "name": "soCREAM/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "8Ae7Uhigx8k4fKdJG7irdPCVDZLvWsJfeTH2t5fr3TVD",
     "deprecated": true,
-    "name": "UBXT/WUSDC",
+    "name": "soUBXT/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "Hze5AUX4Qp1cTujiJ4CsAMRGn4g6ZpgXsmptFn3xxhWg",
     "deprecated": true,
-    "name": "HNT/WUSDC",
+    "name": "soHNT/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "FJq4HX3bUSgF3yQZ8ADALtJYfAyr9fz36SNG18hc3dgF",
     "deprecated": true,
-    "name": "FRONT/WUSDC",
+    "name": "soFRONT/soUSDC",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "BZMuoQ2i2noNUXMdrRDivc7MwjGspNJTCfZkdHMwK18T",
     "deprecated": true,
-    "name": "ALEPH/WUSDC",
+    "name": "soALEPH/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "5LgJphS6D5zXwUVPU7eCryDBkyta3AidrJ5vjNU6BcGW",
     "deprecated": true,
-    "name": "BTC/WUSDC",
+    "name": "BTC/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "DmEDKZPXXkWgaYiKgWws2ZXWWKCh41eryDPRVD4zKnD9",
     "deprecated": true,
-    "name": "ETH/WUSDC",
+    "name": "soETH/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "EBFTQNg2QjyxV7WDDenoLbfLLXLcbSz6w1YrdTCGPWT5",
     "deprecated": true,
-    "name": "SOL/WUSDC",
+    "name": "SOL/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "8YmQZRXGizZXYPCDmxgjwB8X8XN4PZG7MMwNg76iAmPZ",
     "deprecated": true,
-    "name": "SRM/WUSDC",
+    "name": "SRM/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "9vFuX2BizwinWjkZLQTmThDcNMFEcY3wVXYuqnRQtcD",
     "deprecated": true,
-    "name": "SUSHI/WUSDC",
+    "name": "soSUSHI/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "C5NReXAeQhfjiDCGPFj1UUmDxDqF8v2CUVKoYuQqb4eW",
     "deprecated": true,
-    "name": "SXP/WUSDC",
+    "name": "soSXP/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "58H7ZRmiyWtsrz2sQGz1qQCMW6n7447xhNNehUSQGPj5",
     "deprecated": true,
-    "name": "MSRM/WUSDC",
+    "name": "MSRM/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "ES8skmkEeyH1BYFThd2FtyaFKhkqtwH7XWp8mXptv3vg",
     "deprecated": true,
-    "name": "FTT/WUSDC",
+    "name": "soFTT/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "Gw78CYLLFbgmmn4rps9KoPAnNtBQ2S1foL2Mn6Z5ZHYB",
     "deprecated": true,
-    "name": "YFI/WUSDC",
+    "name": "soYFI/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "WjfsTPyrvUUrhGJ9hVQFubMnKDcnQS8VxSXU7L2gLcA",
     "deprecated": true,
-    "name": "LINK/WUSDC",
+    "name": "soLINK/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "2ZmB255T4FVUugpeXTFxD6Yz5GE47yTByYvqSTDUbk3G",
     "deprecated": true,
-    "name": "HGET/WUSDC",
+    "name": "soHGET/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "FGJtCDXoHLHjagP5Ht6xcUFt2rW3z8MJPe87rFKP2ZW6",
     "deprecated": true,
-    "name": "CREAM/WUSDC",
+    "name": "soCREAM/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7K6MPog6LskZmyaYwqtLvRUuedoiE68nirbQ9tK3LasE",
     "deprecated": true,
-    "name": "UBXT/WUSDC",
+    "name": "soUBXT/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "9RyozJe3bkAFfH3jmoiKHjkWCoLTxn7aBQSi6YfaV6ab",
     "deprecated": true,
-    "name": "HNT/WUSDC",
+    "name": "soHNT/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "AGtBbGuJZiv3Ko3dfT4v6g4kCqnNc9DXfoGLe5HpjmWx",
     "deprecated": true,
-    "name": "FRONT/WUSDC",
+    "name": "soFRONT/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "AA1HSrsMcRNzjaQfRMTNarHR9B7e4U79LJ2319UtiqPF",
     "deprecated": true,
-    "name": "AKRO/WUSDC",
+    "name": "soAKRO/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "AUAobJdffexcoJBMeyLorpShu3ZtG9VvPEPjoeTN4u5Z",
     "deprecated": true,
-    "name": "HXRO/WUSDC",
+    "name": "soHXRO/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "GpdYLFbKHeSeDGqsnQ4jnP7D1294iBpQcsN1VPwhoaFS",
     "deprecated": true,
-    "name": "UNI/WUSDC",
+    "name": "soUNI/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "sxS9EdTx1UPe4j2c6Au9f1GKZXrFj5pTgNKgjGGtGdY",
     "deprecated": true,
-    "name": "KEEP/WUSDC",
+    "name": "soKEEP/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "CfnnU38ACScF6pcurxSB3FLXeZmfFYunVKExeUyosu5P",
     "deprecated": true,
-    "name": "MATH/WUSDC",
+    "name": "soMATH/soUSDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7NR5GDouQYkkfppVkNhpa4HfJ2LwqUQymE3b4CYQiYHa",
     "deprecated": true,
-    "name": "ALEPH/USDC",
+    "name": "soALEPH/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
@@ -242,7 +242,7 @@
   {
     "address": "H5uzEytiByuXt964KampmuNCurNDwkVVypkym75J2DQW",
     "deprecated": true,
-    "name": "ETH/USDC",
+    "name": "soETH/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
@@ -260,13 +260,13 @@
   {
     "address": "7LVJtqSrF6RudMaz5rKGTmR3F3V5TKoDcN6bnk68biYZ",
     "deprecated": true,
-    "name": "SUSHI/USDC",
+    "name": "soSUSHI/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "13vjJ8pxDMmzen26bQ5UrouX8dkXYPW1p3VLVDjxXrKR",
     "deprecated": true,
-    "name": "SXP/USDC",
+    "name": "soSXP/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
@@ -278,91 +278,91 @@
   {
     "address": "FfDb3QZUdMW2R2aqJQgzeieys4ETb3rPrFFfPSemzq7R",
     "deprecated": true,
-    "name": "FTT/USDC",
+    "name": "soFTT/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "4QL5AQvXdMSCVZmnKXiuMMU83Kq3LCwVfU8CyznqZELG",
     "deprecated": true,
-    "name": "YFI/USDC",
+    "name": "soYFI/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7JCG9TsCx3AErSV3pvhxiW4AbkKRcJ6ZAveRmJwrgQ16",
     "deprecated": true,
-    "name": "LINK/USDC",
+    "name": "soLINK/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "3otQFkeQ7GNUKT3i2p3aGTQKS2SAw6NLYPE5qxh3PoqZ",
     "deprecated": true,
-    "name": "HGET/USDC",
+    "name": "soHGET/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "2M8EBxFbLANnCoHydypL1jupnRHG782RofnvkatuKyLL",
     "deprecated": true,
-    "name": "CREAM/USDC",
+    "name": "soCREAM/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "3UqXdFtNBZsFrFtRGAWGvy9R8H6GJR2hAyGRdYT9BgG3",
     "deprecated": true,
-    "name": "UBXT/USDC",
+    "name": "soUBXT/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "9jiasgdYGGh34fAbBQSwkKe1dYSapXbjy2sLsYpetqFp",
     "deprecated": true,
-    "name": "HNT/USDC",
+    "name": "soHNT/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7oKqJhnz9b8af8Mw47dieTiuxeaHnRYYGBiqCrRpzTRD",
     "deprecated": true,
-    "name": "FRONT/USDC",
+    "name": "soFRONT/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "F1rxD8Ns5w4WzVcTRdaJ96LG7YKaA5a25BBmM32yFP4b",
     "deprecated": true,
-    "name": "AKRO/USDC",
+    "name": "soAKRO/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "6ToedDwjRCvrcKX7fnHSTA9uABQe1dcLK6YgS5B9M3wo",
     "deprecated": true,
-    "name": "HXRO/USDC",
+    "name": "soHXRO/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "FURvCsDUiuUaxZ13pZqQbbfktFGWmQVTHz7tL992LQVZ",
     "deprecated": true,
-    "name": "UNI/USDC",
+    "name": "soUNI/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "EcfDRMrEJ3yW4SgrRyyxTPoKqAZDNSBV8EerigT7BNSS",
     "deprecated": true,
-    "name": "KEEP/USDC",
+    "name": "soKEEP/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "2bPsJ6bZ9KDLfJ8QgSN1Eb4mRsbAiaGyHN6cJkoVLpwd",
     "deprecated": true,
-    "name": "MATH/USDC",
+    "name": "soMATH/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "B1GypajMh7S8zJVp6M1xMfu6zGsMgvYrt3cSn9wG7Dd6",
     "deprecated": true,
-    "name": "TOMO/USDC",
+    "name": "soTOMO/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "rPTGvVrNFYzBeTEcYnHiaWGNnkSXsWNNjUgk771LkwJ",
     "deprecated": true,
-    "name": "LUA/USDC",
+    "name": "soLUA/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
@@ -386,7 +386,7 @@
   {
     "address": "GcoKtAmTy5QyuijXSmJKBtFdt99e6Buza18Js7j9AJ6e",
     "deprecated": false,
-    "name": "ALEPH/USDC",
+    "name": "soALEPH/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -398,7 +398,7 @@
   {
     "address": "4tSvZvnbyzHXLMTiFonMyxZoHmFqau1XArcRCVHLZ5gX",
     "deprecated": false,
-    "name": "ETH/USDC",
+    "name": "soETH/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -410,13 +410,13 @@
   {
     "address": "A1Q9iJDVVS8Wsswr9ajeZugmj64bQVCYLZQLra2TMBMo",
     "deprecated": false,
-    "name": "SUSHI/USDC",
+    "name": "soSUSHI/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "4LUro5jaPaTurXK737QAxgJywdhABnFAMQkXX4ZyqqaZ",
     "deprecated": false,
-    "name": "SXP/USDC",
+    "name": "soSXP/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -428,85 +428,85 @@
   {
     "address": "2Pbh1CvRVku1TgewMfycemghf6sU9EyuFDcNXqvRmSxc",
     "deprecated": false,
-    "name": "FTT/USDC",
+    "name": "soFTT/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "7qcCo8jqepnjjvB5swP4Afsr3keVBs6gNpBTNubd1Kr2",
     "deprecated": false,
-    "name": "YFI/USDC",
+    "name": "soYFI/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "3hwH1txjJVS8qv588tWrjHfRxdqNjBykM1kMcit484up",
     "deprecated": false,
-    "name": "LINK/USDC",
+    "name": "soLINK/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "88vztw7RTN6yJQchVvxrs6oXUDryvpv9iJaFa1EEmg87",
     "deprecated": false,
-    "name": "HGET/USDC",
+    "name": "soHGET/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "7nZP6feE94eAz9jmfakNJWPwEKaeezuKKC5D1vrnqyo2",
     "deprecated": false,
-    "name": "CREAM/USDC",
+    "name": "soCREAM/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "2wr3Ab29KNwGhtzr5HaPCyfU1qGJzTUAN4amCLZWaD1H",
     "deprecated": false,
-    "name": "UBXT/USDC",
+    "name": "soUBXT/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "CnUV42ZykoKUnMDdyefv5kP6nDSJf7jFd7WXAecC6LYr",
     "deprecated": false,
-    "name": "HNT/USDC",
+    "name": "soHNT/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "9Zx1CvxSVdroKMMWf2z8RwrnrLiQZ9VkQ7Ex3syQqdSH",
     "deprecated": false,
-    "name": "FRONT/USDC",
+    "name": "soFRONT/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "5CZXTTgVZKSzgSA3AFMN5a2f3hmwmmJ6hU8BHTEJ3PX8",
     "deprecated": false,
-    "name": "AKRO/USDC",
+    "name": "soAKRO/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "6Pn1cSiRos3qhBf54uBP9ZQg8x3JTardm1dL3n4p29tA",
     "deprecated": false,
-    "name": "HXRO/USDC",
+    "name": "soHXRO/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "6JYHjaQBx6AtKSSsizDMwozAEDEZ5KBsSUzH7kRjGJon",
     "deprecated": false,
-    "name": "UNI/USDC",
+    "name": "soUNI/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "J7cPYBrXVy8Qeki2crZkZavcojf2sMRyQU7nx438Mf8t",
     "deprecated": false,
-    "name": "MATH/USDC",
+    "name": "soMATH/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "8BdpjpSD5n3nk8DQLqPUyTZvVqFu6kcff5bzUX5dqDpy",
     "deprecated": false,
-    "name": "TOMO/USDC",
+    "name": "soTOMO/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "4xyWjQ74Eifq17vbue5Ut9xfFNfuVB116tZLEpiZuAn8",
     "deprecated": false,
-    "name": "LUA/USDC",
+    "name": "soLUA/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -542,439 +542,439 @@
   {
     "address": "3rgacody9SvM88QR83GHaNdEEx4Fe2V2ed5GJp2oeKDr",
     "deprecated": false,
-    "name": "KEEP/USDC",
+    "name": "soKEEP/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "EmCzMQfXMgNHcnRoFwAdPe1i2SuiSzMj1mx6wu3KN2uA",
     "deprecated": true,
-    "name": "ALEPH/WUSDT",
+    "name": "soALEPH/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "8AcVjMG2LTbpkjNoyq8RwysokqZunkjy3d5JDzxC6BJa",
     "deprecated": true,
-    "name": "BTC/WUSDT",
+    "name": "BTC/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "HfCZdJ1wfsWKfYP2qyWdXTT5PWAGWFctzFjLH48U1Hsd",
     "deprecated": true,
-    "name": "ETH/WUSDT",
+    "name": "soETH/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "8mDuvJJSgoodovMRYArtVVYBbixWYdGzR47GPrRT65YJ",
     "deprecated": true,
-    "name": "SOL/WUSDT",
+    "name": "SOL/soUSDT",
     "programId": "BJ3jrUzddfuSrZHXSCxMUUQsjKEyLmuuyZebkcaFp2fg"
   },
   {
     "address": "HARFLhSq8nECZk4DVFKvzqXMNMA9a3hjvridGMFizeLa",
     "deprecated": true,
-    "name": "SRM/WUSDT",
+    "name": "SRM/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "DzFjazak6EKHnaB2w6qSsArnj28CV1TKd2Smcj9fqtHW",
     "deprecated": true,
-    "name": "SUSHI/WUSDT",
+    "name": "soSUSHI/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "GuvWMATdEV6DExWnXncPYEzn4ePWYkvGdC8pu8gsn7m7",
     "deprecated": true,
-    "name": "SXP/WUSDT",
+    "name": "soSXP/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "H4snTKK9adiU15gP22ErfZYtro3aqR9BTMXiH3AwiUTQ",
     "deprecated": true,
-    "name": "MSRM/WUSDT",
+    "name": "MSRM/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "DHDdghmkBhEpReno3tbzBPtsxCt6P3KrMzZvxavTktJt",
     "deprecated": true,
-    "name": "FTT/WUSDT",
+    "name": "soFTT/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "5zu5bTZZvqESAAgFsr12CUMxdQvMrvU9CgvC1GW8vJdf",
     "deprecated": true,
-    "name": "YFI/WUSDT",
+    "name": "soYFI/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "F5xschQBMpu1gD2q1babYEAVJHR1buj1YazLiXyQNqSW",
     "deprecated": true,
-    "name": "LINK/WUSDT",
+    "name": "soLINK/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "BAbc9baz4hV1hnYjWSJ6cZDRjfvziWbYGQu9UFkcdUmx",
     "deprecated": true,
-    "name": "HGET/WUSDT",
+    "name": "soHGET/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "EBxJWA2nLV57ZntbjizxH527ZjPNLT5cpUHMnY5k3oq",
     "deprecated": true,
-    "name": "CREAM/WUSDT",
+    "name": "soCREAM/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "46VdEkj4MJwZinwVb3Y7DUDpVXLNb9YW7P2waKU3vCqr",
     "deprecated": true,
-    "name": "UBXT/WUSDT",
+    "name": "soUBXT/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "Hc22rHKrhbrZBaQMmhJvPTkp1yDr31PDusU8wKoqFSZV",
     "deprecated": true,
-    "name": "HNT/WUSDT",
+    "name": "soHNT/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "HFoca5HKwiTPpw9iUY5iXWqzkXdu88dS7YrpSvt2uhyF",
     "deprecated": true,
-    "name": "FRONT/WUSDT",
+    "name": "soFRONT/soUSDT",
     "programId": "4ckmDgGdxQoPDLUkDT3vHgSAkzA3QRdNq5ywwY4sUSJn"
   },
   {
     "address": "5xnYnWca2bFwC6cPufpdsCbDJhMjYCC59YgwoZHEfiee",
     "deprecated": true,
-    "name": "ALEPH/WUSDT",
+    "name": "soALEPH/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "EXnGBBSamqzd3uxEdRLUiYzjJkTwQyorAaFXdfteuGXe",
     "deprecated": true,
-    "name": "BTC/WUSDT",
+    "name": "BTC/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "5abZGhrELnUnfM9ZUnvK6XJPoBU5eShZwfFPkdhAC7o",
     "deprecated": true,
-    "name": "ETH/WUSDT",
+    "name": "soETH/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932",
     "deprecated": true,
-    "name": "SOL/WUSDT",
+    "name": "SOL/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "H3APNWA8bZW2gLMSq5sRL41JSMmEJ648AqoEdDgLcdvB",
     "deprecated": true,
-    "name": "SRM/WUSDT",
+    "name": "SRM/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "4uZTPc72sCDcVRfKKii67dTPm2Xe4ri3TYnGcUQrtnU9",
     "deprecated": true,
-    "name": "SUSHI/WUSDT",
+    "name": "soSUSHI/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "33GHmwG9woY95JuWNi74Aa8uKvysSXxif9P1EwwkrCRz",
     "deprecated": true,
-    "name": "SXP/WUSDT",
+    "name": "soSXP/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "FUaF58sDrgbqakHTR8RUwRLauSofRTjqyCsqThFPh6YM",
     "deprecated": true,
-    "name": "MSRM/WUSDT",
+    "name": "MSRM/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "5NqjQVXLuLSDnsnQMfWp3rF9gbWDusWG4B1Xwtk3rZ5S",
     "deprecated": true,
-    "name": "FTT/WUSDT",
+    "name": "soFTT/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "97NiXHUNkpYd1eb2HthSDGhaPfepuqMAV3QsZhAgb1wm",
     "deprecated": true,
-    "name": "YFI/WUSDT",
+    "name": "soYFI/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "hBswhpNyz4m5nt4KwtCA7jYXvh7VmyZ4TuuPmpaKQb1",
     "deprecated": true,
-    "name": "LINK/WUSDT",
+    "name": "soLINK/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "GaeUpY7CT8rjoeVGjY1t3mJJDd1bdXxYWtrGSpsVFors",
     "deprecated": true,
-    "name": "HGET/WUSDT",
+    "name": "soHGET/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7qq9BABQvTWKZuJ5fX2PeTKX6XVtduEs9zW9WS21fSzN",
     "deprecated": true,
-    "name": "CREAM/WUSDT",
+    "name": "soCREAM/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "DCHvVahuLTNWBGUtEzF5GrTdx5FRpxqEJiS6Ru1hrDfD",
     "deprecated": true,
-    "name": "UBXT/WUSDT",
+    "name": "soUBXT/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "DWjJ8VHdGYBxDQYdrRBVDWkHswrgjuBFEv5pBhiRoPBz",
     "deprecated": true,
-    "name": "HNT/WUSDT",
+    "name": "soHNT/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "56eqxJYzPigm4FkigiBdsfebjMgAbKNh24E7oiKLBtye",
     "deprecated": true,
-    "name": "FRONT/WUSDT",
+    "name": "soFRONT/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "FQbCNSVH3RgosCPB4CJRstkLh5hXkvuXzAjQzT11oMYo",
     "deprecated": true,
-    "name": "AKRO/WUSDT",
+    "name": "soAKRO/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "Fs5xtGUmJTYo8Ao75M3R3m3mVX53KMUhzfXCmyRLnp2P",
     "deprecated": true,
-    "name": "HXRO/WUSDT",
+    "name": "soHXRO/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "ChKV7mxecPqFPGYJjhzowPHDiLKFWXXVujUiE3EWxFcg",
     "deprecated": true,
-    "name": "UNI/WUSDT",
+    "name": "soUNI/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "6N3oU7ALvn2RPwdpYVzPBgQJ8njT29inBbS2tSrwx8fh",
     "deprecated": true,
-    "name": "KEEP/WUSDT",
+    "name": "soKEEP/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "5P6dJbyKySFXMYNWiEcNQu8xPRYsehYzCeVpae9Ueqrg",
     "deprecated": true,
-    "name": "MATH/WUSDT",
+    "name": "soMATH/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "H7c8FcQPJ2E5tJmpWBPSi7xCAbk8immdtUxKFRUyE4Ro",
     "deprecated": true,
-    "name": "TOMO/WUSDT",
+    "name": "soTOMO/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "7PSeX1AEtBY9KvgegF5rUh452VemMh7oDzFtJgH7sxMG",
     "deprecated": true,
-    "name": "LUA/WUSDT",
+    "name": "soLUA/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "AF2oQQaLtcrTnQyVs3EPTdyw57TPaK6njKYDq2Qw7LqP",
     "deprecated": true,
-    "name": "SWAG/WUSDT",
+    "name": "soSWAG/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "9TE15E5h61zJ5VmQAAHkGrAuQdFTth33aBbKdcrppZBp",
     "deprecated": true,
-    "name": "FIDA/WUSDT",
+    "name": "FIDA/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "8HEaA1vSA5mGQoHcvRPNibnuZvnUpSjJJru9HJNH3SqM",
     "deprecated": true,
-    "name": "KIN/WUSDT",
+    "name": "KIN/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "8EuuEwULFM7n7zthPjC7kA64LPRzYkpAyuLFiLuVg7D4",
     "deprecated": true,
-    "name": "WUSDT/USDC",
+    "name": "soUSDT/USDC",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "8grUs4WZoTs4KJ8LfRNUBs6SNkMTp5BnVRzJgQ2ranDT",
     "deprecated": true,
-    "name": "MAPS/WUSDT",
+    "name": "MAPS/soUSDT",
     "programId": "EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o"
   },
   {
     "address": "FoCuWt4KboucUg2PwmQ3dbkvLqYPLnAo1Rsm8p7QPyf",
     "deprecated": true,
-    "name": "ALEPH/WUSDT",
+    "name": "soALEPH/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "5r8FfnbNYcQbS1m4CYmoHYGjBtu6bxfo6UJHNRfzPiYH",
     "deprecated": true,
-    "name": "BTC/WUSDT",
+    "name": "BTC/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "71CtEComq2XdhGNbXBuYPmosAjMCPSedcgbNi5jDaGbR",
     "deprecated": true,
-    "name": "ETH/WUSDT",
+    "name": "soETH/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "EZyQ9zyqQsw3QcsLksoWyd1UFVjHZkzRx8N4ZMnZQrS2",
     "deprecated": true,
-    "name": "SRM/WUSDT",
+    "name": "SRM/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "6ERBjj692XHLWwWSRAUpiKenXshcwmPqhMy7RMapeoKa",
     "deprecated": true,
-    "name": "SUSHI/WUSDT",
+    "name": "soSUSHI/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "CQ3kAGxPmpBbak2RSHWyMeRhyLYbH6oVZHJxgjzDLpLW",
     "deprecated": true,
-    "name": "SXP/WUSDT",
+    "name": "soSXP/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "2Hqn46jhwaQMQ3zEnHtxrWxQZom6qwLXAgdsFJM1Srwh",
     "deprecated": true,
-    "name": "MSRM/WUSDT",
+    "name": "MSRM/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "G5jqZNo2UVCTnJxgEhKCYvqFRs3MxsnH8Bervq3rfLoL",
     "deprecated": true,
-    "name": "FTT/WUSDT",
+    "name": "soFTT/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "CbwtTHEpfTnCyLw4GoTbKk7WyrXkuATLfLadY2odBSsY",
     "deprecated": true,
-    "name": "YFI/WUSDT",
+    "name": "soYFI/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "5GjhBAYx8pYeCeUQt7rt93KQZnoQFuDq9Jx4iqq97Mip",
     "deprecated": true,
-    "name": "LINK/WUSDT",
+    "name": "soLINK/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "9jMPV9E23pTirMjC7vz5suRNkd25311G3Httg7jTib8R",
     "deprecated": true,
-    "name": "CREAM/WUSDT",
+    "name": "soCREAM/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "DsSz9KWT97T4RewRTqTNDpNFQyxMPcuYNAJw2xHAzSiZ",
     "deprecated": true,
-    "name": "UBXT/WUSDT",
+    "name": "soUBXT/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "3k1sURztjxhjYczjyioQ7y2UkMB6K5Ksi3SWvLeLx6Ex",
     "deprecated": true,
-    "name": "HNT/WUSDT",
+    "name": "soHNT/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "B791G8UCahfmABVcR2wPAMK6LJnuqxSAqiG6wX3mmVVM",
     "deprecated": true,
-    "name": "FRONT/WUSDT",
+    "name": "soFRONT/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "95f7fxfUh8WqUTrdjorHRXm6rTfkWqr23ioGMmKMjedP",
     "deprecated": true,
-    "name": "AKRO/WUSDT",
+    "name": "soAKRO/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "H4RxtmQ4P3TYPt78G3DuHgaGzyFct6MfaeYneLB5PyeG",
     "deprecated": true,
-    "name": "HXRO/WUSDT",
+    "name": "soHXRO/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "7myaZEGZf9m72T1Mqm8GTx5MnmSFS5NCXSwRP18W4EA3",
     "deprecated": true,
-    "name": "UNI/WUSDT",
+    "name": "soUNI/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "7cRKzNoqjF9VtzvdnP129VYP3izivk9iY3jMJBMzREVT",
     "deprecated": true,
-    "name": "HGET/WUSDT",
+    "name": "soHGET/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "GV9fYzdwipoaagXFxe5tzDMPcmSVQati5CUvBPsEZThH",
     "deprecated": true,
-    "name": "MATH/WUSDT",
+    "name": "soMATH/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "AaMLXcwYYi5fA41JNCB2ukAmQyKHitYx5NnpsiWWev6R",
     "deprecated": true,
-    "name": "TOMO/WUSDT",
+    "name": "soTOMO/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "5ZeNLrduGi3WkH9CPwv2Zpbkh38MH8v63aSi2aBUW23g",
     "deprecated": true,
-    "name": "LUA/WUSDT",
+    "name": "soLUA/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "Ec1aq54XKH9o5fe169cU2sCcxxTP54eeQCe77SpizKuc",
     "deprecated": true,
-    "name": "WUSDT/USDC",
+    "name": "soUSDT/USDC",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "G3uhFg2rBFunHUXtCera13vyQ5KCS8Hx3d4HohLoZbT5",
     "deprecated": true,
-    "name": "SOL/WUSDT",
+    "name": "SOL/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "2NMTG7tFZidRpQk9Sf4dgQyJb9HxKCyXjQdiuXww3sKm",
     "deprecated": true,
-    "name": "SWAG/WUSDT",
+    "name": "soSWAG/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "7QpJAiwGmqY1SiucjfPXvgeWwCobyV6hZSgzMysZX6Ww",
     "deprecated": true,
-    "name": "FIDA/WUSDT",
+    "name": "FIDA/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "CmLhvXARncLncE1949XBfQWeJh6Zvw3FE5A3Z5ecPYQH",
     "deprecated": true,
-    "name": "KIN/WUSDT",
+    "name": "KIN/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "FhP3X2ptdi7L1RtWK9Vfow5dyzD92gfXiA57e8eqxvka",
     "deprecated": true,
-    "name": "MAPS/WUSDT",
+    "name": "MAPS/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "DE7xJE2EkaV81wLabDMuhBzUwFhhwfURLdz1aXBBQZQ1",
     "deprecated": true,
-    "name": "KEEP/WUSDT",
+    "name": "soKEEP/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -986,49 +986,49 @@
   {
     "address": "7dLVkUfBVfCGkFhSXDCq1ukM9usathSgS716t643iFGF",
     "deprecated": false,
-    "name": "ETH/USDT",
+    "name": "soETH/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "8afKwzHR3wJE7W7Y5hvQkngXh6iTepSZuutRMMy96MjR",
     "deprecated": false,
-    "name": "SXP/USDT",
+    "name": "soSXP/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "cgani53cMZgYfRMgSrNekJTMaLmccRfspsfTbXWRg7u",
     "deprecated": false,
-    "name": "CEL/USDT",
+    "name": "soCEL/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "Gyp1UGRgbrb6z8t7fpssxEKQgEmcJ4pVnWW3ds2p6ZPY",
     "deprecated": false,
-    "name": "ALEPH/USDT",
+    "name": "soALEPH/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "4ztJEvQyryoYagj2uieep3dyPwG2pyEwb2dKXTwmXe82",
     "deprecated": false,
-    "name": "CREAM/USDT",
+    "name": "soCREAM/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "HEGnaVL5i48ubPBqWAhodnZo8VsSLzEM3Gfc451DnFj9",
     "deprecated": false,
-    "name": "KEEP/USDT",
+    "name": "soKEEP/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "8FpuMGLtMZ7Wt9ZvyTGuTVwTwwzLYfS5NZWcHxbP1Wuh",
     "deprecated": false,
-    "name": "HNT/USDT",
+    "name": "soHNT/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "5GAPymgnnWieGcRrcghZdA3aanefqa4cZx1ZSE8UTyMV",
     "deprecated": false,
-    "name": "MAPS/USDT",
+    "name": "soMAPS/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1046,7 +1046,7 @@
   {
     "address": "FcPet5fz9NLdbXwVM6kw2WTHzRAD7mT78UjwTpawd7hJ",
     "deprecated": false,
-    "name": "RSR/USDT",
+    "name": "soRSR/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1070,25 +1070,25 @@
   {
     "address": "Hr3wzG8mZXNHV7TuL6YqtgfVUesCqMxGYCEyP3otywZE",
     "deprecated": false,
-    "name": "FTT/USDT",
+    "name": "soFTT/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "HLvRdctRB48F9yLnu9E24LUTRt89D48Z35yi1HcxayDf",
     "deprecated": false,
-    "name": "AKRO/USDT",
+    "name": "soAKRO/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "2SSnWNrc83otLpfRo792P6P3PESZpdr8cu2r8zCE6bMD",
     "deprecated": false,
-    "name": "UNI/USDT",
+    "name": "soUNI/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "F1T7b6pnR8Pge3qmfNUfW6ZipRDiGpMww6TKTrRU4NiL",
     "deprecated": false,
-    "name": "UBXT/USDT",
+    "name": "soUBXT/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1100,43 +1100,43 @@
   {
     "address": "35tV8UsHH8FnSAi3YFRrgCu4K9tb883wKnAXpnihot5r",
     "deprecated": false,
-    "name": "LUA/USDT",
+    "name": "soLUA/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "6DgQRTpJTnAYBSShngAVZZDq7j9ogRN1GfSQ3cq9tubW",
     "deprecated": false,
-    "name": "SUSHI/USDT",
+    "name": "soSUSHI/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "2WghiBkDL2yRhHdvm8CpprrkmfguuQGJTCDfPSudKBAZ",
     "deprecated": false,
-    "name": "MATH/USDT",
+    "name": "soMATH/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "ErQXxiNfJgd4fqQ58PuEw5xY35TZG84tHT6FXf5s4UxY",
     "deprecated": false,
-    "name": "HGET/USDT",
+    "name": "soHGET/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "CGC4UgWwqA9PET6Tfx6o6dLv94EK2coVkPtxgNHuBtxj",
     "deprecated": false,
-    "name": "FRONT/USDT",
+    "name": "soFRONT/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "GnKPri4thaGipzTbp8hhSGSrHgG4F8MFiZVrbRn16iG2",
     "deprecated": false,
-    "name": "TOMO/USDT",
+    "name": "soTOMO/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "6bxuB5N3bt3qW8UnPNLgMMzDq5sEH8pFmYJYGgzvE11V",
     "deprecated": false,
-    "name": "AAVE/USDT",
+    "name": "soAAVE/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1148,7 +1148,7 @@
   {
     "address": "4absuMsgemvdjfkgdLQq1zKEjw3dHBoCWkzKoctndyqd",
     "deprecated": false,
-    "name": "HXRO/USDT",
+    "name": "soHXRO/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1160,19 +1160,19 @@
   {
     "address": "3Xg9Q4VtZhD4bVYJbTfgGWFV5zjE3U7ztSHa938zizte",
     "deprecated": false,
-    "name": "YFI/USDT",
+    "name": "soYFI/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "3yEZ9ZpXSQapmKjLAGKZEzUNA1rcupJtsDp5mPBWmGZR",
     "deprecated": false,
-    "name": "LINK/USDT",
+    "name": "soLINK/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
     "address": "J2XSt77XWim5HwtUM8RUwQvmRXNZsbMKpp5GTKpHafvf",
     "deprecated": false,
-    "name": "SWAG/USDT",
+    "name": "soSWAG/USDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {
@@ -1190,7 +1190,7 @@
   {
     "address": "HdBhZrnrxpje39ggXnTb6WuTWVvj5YKcSHwYGQCRsVj",
     "deprecated": false,
-    "name": "OXY/WUSDT",
+    "name": "OXY/soUSDT",
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
   },
   {

--- a/packages/serum/src/markets.json
+++ b/packages/serum/src/markets.json
@@ -1318,5 +1318,341 @@
     "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
     "deprecated": false,
     "address": "5cLrMai1DsLRYc1Nio9qMTicsWtvzjzZfJPXyAoF4t1Z"
+  },
+  {
+    "name": "AAVE/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "8WZrmdpLckptiVKd2fPHPjewRVYQGQkjxi9vzRYG1sfs"
+  },
+  {
+    "name": "AAVE/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "LghsMERQWQFK3zWMTrUkoyAJARQw2wSmcYZjexeN3zy"
+  },
+  {
+    "name": "AKRO/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "G3h8NZgJozk9crme2me6sKDJuSQ12mNCtvC9NbSWqGuk"
+  },
+  {
+    "name": "AKRO/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "DvbiPxKzuXZPcmUcYDqBz1tvUrXYPsNrRAjSeuwHtmEA"
+  },
+  {
+    "name": "ALEPH/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "Fw4mvuE7KZmTjQPxP2sRpHwPDfRMWnKBupFZGyW9CAQH"
+  },
+  {
+    "name": "ALEPH/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "GZeHR8uCTVoHVDZFRVXTgm386DK1EKehy9yMS3BFChcL"
+  },
+  {
+    "name": "CEL/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "79ESpYSb2hM14KTRXPZUwDkxUGC5irE2esd1vxdXfnZz"
+  },
+  {
+    "name": "CEL/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "J9ww1yufRNDDbUbDXmew2mW2ozkx7cme7dMvKjMQVHrL"
+  },
+  {
+    "name": "CREAM/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "4pdQ2D4gehMhGu4z9jeQbEPUFbTxB5qcPr3zCynjJGyp"
+  },
+  {
+    "name": "CREAM/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "6fspxMfBmYFTGFBDN5MU33A55i2MkGr7eSjBLPCAU6y9"
+  },
+  {
+    "name": "ETH/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "8Gmi2HhZmwQPVdCwzS7CM66MGstMXPcTVHA7jF19cLZz"
+  },
+  {
+    "name": "ETH/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "ch7kmPrtoQUSEPBggcNAvLGiMQkJagVwd3gDYfd8m7Q"
+  },
+  {
+    "name": "FRONT/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "B95oZN5HCLGmFAhbzReWBA9cuSGPFQAXeuhm2FfpdrML"
+  },
+  {
+    "name": "FRONT/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "DZTYyy1L5Pr6DmTtYY5bEuU9g3LQ4XGvuYiN3zS25yG7"
+  },
+  {
+    "name": "FTT/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "2wteg25ch227n4Rh1CN4WNrDZXBpRBpWJ48mEC2K7f4r"
+  },
+  {
+    "name": "FTT/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "BoHojHESAv4McZx9gXd1bWTZMq25JYyGz4qL1m5C3nvk"
+  },
+  {
+    "name": "HGET/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "27e1mB6UoPohbc3MmwMXu5QM7b2E3k5Mbhwv6JguwyXg"
+  },
+  {
+    "name": "HGET/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "BdRzTEKb7Qdu4tWts5zXjwcpQErZxEzvShKZ5QcthMag"
+  },
+  {
+    "name": "HXRO/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "CBb5zXwNRB73WVjs2m21P5prcEZa6SWmej74Vzxh8dRm"
+  },
+  {
+    "name": "HXRO/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "3BScwNxtMrEcQ5VTHyXHYQR98dTaxfyXGaLkuSjBY1dW"
+  },
+  {
+    "name": "LINK/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "FJMjxMCiDKn16TLhXUdEbVDH5wC6k9EHYJTcrH6NcbDE"
+  },
+  {
+    "name": "LINK/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "Gr2KmhK7Upr4uW56B1QQrJuhhgmot6zAHJeZALTMStiX"
+  },
+  {
+    "name": "LUA/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "J9imTcEeahZqKuaoQaPcCeSGCMWL8qSACpK4B7bC8NN4"
+  },
+  {
+    "name": "LUA/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "BMJ3CvQZ57cNnuc3Lz5Pb6cW6Sr9kZGz3qz2bJQTE24A"
+  },
+  {
+    "name": "MATH/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "G8L1YLrktaG1t8YBMJs3CwV96nExvJJCSpw3DARPDjE2"
+  },
+  {
+    "name": "MATH/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "CkvNfATB7nky8zPLuwS9bgcFbVRkQdkd5zuKEovyo9rs"
+  },
+  {
+    "name": "RAY/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "2xiv8A5xrJ7RnGdxXB42uFEkYHJjszEhaJyKKt4WaLep"
+  },
+  {
+    "name": "RSR/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "GqgkxEswUwHBntmzb5GpUhKrVpJhzreSruZycuJwdNwB"
+  },
+  {
+    "name": "RSR/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "2j2or38X2FUbpkK4gkgvjDtqN3ibkKw3v5yn7o2gHqPc"
+  },
+  {
+    "name": "SUSHI/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "3uWVMWu7cwMnYMAAdtsZNwaaqeeeZHARGZwcExnQiFay"
+  },
+  {
+    "name": "SUSHI/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "T3aC6qcPAJtX1gqkckfSxBPdPWziz5fLYRt5Dz3Nafq"
+  },
+  {
+    "name": "SWAG/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "wSkeLMv3ktJyLm51bvQWxY2saGKqGxbnUFimPxbgEvQ"
+  },
+  {
+    "name": "SWAG/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "6URQ4zFWvPm1fhJCKKWorrh8X3mmTFiDDyXEUmSf8Rb2"
+  },
+  {
+    "name": "SXP/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "G5F84rfqmWqzZv5GBpSn8mMwW8zJ2B4Y1GpGupiwjHNM"
+  },
+  {
+    "name": "SXP/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "2FQbPW1ticJz2SMMbEXxbKWJKmw1wLc6ggSP2HyzdMen"
+  },
+  {
+    "name": "UBXT/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "Hh4p7tJpqkGW6xsHM2LiPPMpJg43fwn5TbmVmfrURdLY"
+  },
+  {
+    "name": "UBXT/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "5xhjc3ZtAwnBK3qsaro28VChL7WrxY9N4SG6UZpYxpGc"
+  },
+  {
+    "name": "UNI/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "B7b5rjQuqQCuGqmUBWmcCTqaL3Z1462mo4NArqty6QFR"
+  },
+  {
+    "name": "UNI/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "FrKM6kJtAjXknHPEpkrQtJSXZwUxV5dq26wDpc4YjQST"
+  },
+  {
+    "name": "YFI/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "BiJXGFc1c4gyPpv9HLRJoKbZewWQrTCHGuxYKjYMQJpC"
+  },
+  {
+    "name": "YFI/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "9sue9TZAeUhNtNAPPGb9dke7rkJeXktGD3u8ZC37GWnQ"
+  },
+  {
+    "name": "AVAX/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "E8JQstcwjuqN5kdMyUJLNuaectymnhffkvfg1j286UCr"
+  },
+  {
+    "name": "AXSet/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "HZCheduA4nsSuQpVww1TiyKZpXSAitqaXxjBD2ymg22X"
+  },
+  {
+    "name": "BNB/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "4UPUurKveNEJgBqJzqHPyi8DhedvpYsMXi7d43CjAg2f"
+  },
+  {
+    "name": "BNB/USDT",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "FjbKNZME5yVSC1R3HJM99kB3yir3q3frS5MteMFD72sV"
+  },
+  {
+    "name": "GALA/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "F7WJsoxTWQRmAwAyFe9APmuVv4HqmhchFtdbR9dvAUDm"
+  },
+  {
+    "name": "MATICpo/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "5WRoQxE59966N2XfD2wYy1uhuyKeoVJ9NBMH6r6RNYEF"
+  },
+  {
+    "name": "ROSE/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "EybAYkmRKCyD4w8AErTG1bqmnvT85LFuPQPMCc8J3yD"
+  },
+  {
+    "name": "SAND/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "3FE2g3cadTJjN3C7gNRavwnv7Yh9Midq7h9KgTVUE7tR"
+  },
+  {
+    "name": "LUNA/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "HBTu8hNaoT3VyiSSzJYa8jwt9sDGKtJviSwFa11iXdmE"
+  },
+  {
+    "name": "SHIB/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "Er7Jp4PADPVHifykFwbVoHdkL1RtZSsx9zGJrPJTrCgW"
+  },
+  {
+    "name": "UST/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "8WmckvEoVGZvtN8knjdzFGbWJ3Sr4BcWdyzSYuCrD4YK"
+  },
+  {
+    "name": "FAB/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "Cud48DK2qoxsWNzQeTL5D8sAiHsGwG8Ev1VMNcYLayxt"
+  },
+  {
+    "name": "JET/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "6pQMoHDC2o8eeFxyTKtfnsr8d48hKFWsRpLHAqVHH2ZP"
+  },
+  {
+    "name": "scnSOL/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "D52sefGCWho2nd5UGxWd7wCftAzeNEMNYZkdEPGEdQTb"
+  },
+  {
+    "name": "stSOL/USDC",
+    "programId": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+    "deprecated": false,
+    "address": "5F7LGsP1LPtaRV7vVKgxwNYX4Vf22xvuzyXjyar7jJqp"
   }
 ]

--- a/packages/tokens/src/mainnet-beta.json
+++ b/packages/tokens/src/mainnet-beta.json
@@ -8,13 +8,13 @@
   {
     "tokenSymbol": "BTC",
     "mintAddress": "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
-    "tokenName": "Wrapped Bitcoin",
+    "tokenName": "Wrapped Bitcoin (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bitcoin/info/logo.png"
   },
   {
-    "tokenSymbol": "ETH",
+    "tokenSymbol": "soETH",
     "mintAddress": "2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk",
-    "tokenName": "Wrapped Ethereum",
+    "tokenName": "Wrapped Ether (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   {
@@ -24,27 +24,27 @@
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/f3ffd0b9ae2165336279ce2f8db1981a55ce30f8/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
   },
   {
-    "tokenSymbol": "YFI",
+    "tokenSymbol": "soYFI",
     "mintAddress": "3JSf5tPeuscJGtaCp5giEiDhv51gQ4v3zWg8DGgyLfAB",
-    "tokenName": "Wrapped YFI",
+    "tokenName": "Wrapped YFI (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
   },
   {
-    "tokenSymbol": "LINK",
+    "tokenSymbol": "soLINK",
     "mintAddress": "CWE8jPTUYhdCTZYWPTe1o5DFqfdjzWKc9WKz6rSjQUdG",
-    "tokenName": "Wrapped Chainlink",
+    "tokenName": "Wrapped Chainlink (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
   },
   {
     "tokenSymbol": "XRP",
     "mintAddress": "Ga2AXHpfAF6mv2ekZwcsJFqu7wB4NV331qNH7fW9Nst8",
-    "tokenName": "Wrapped XRP",
+    "tokenName": "Wrapped XRP (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ripple/info/logo.png"
   },
   {
-    "tokenSymbol": "WUSDT",
+    "tokenSymbol": "soUSDT",
     "mintAddress": "BQcdHdAQW1hczDbBi9hiegXAR7A98Q9jx3X3iBBBDiq4",
-    "tokenName": "Wrapped USDT",
+    "tokenName": "Wrapped USDT (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/f3ffd0b9ae2165336279ce2f8db1981a55ce30f8/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
   },
   {
@@ -54,65 +54,65 @@
     "icon": "https://cdn.jsdelivr.net/gh/solana-labs/explorer/public/tokens/usdt.svg"
   },
   {
-    "tokenSymbol": "SUSHI",
+    "tokenSymbol": "soSUSHI",
     "mintAddress": "AR1Mtgh7zAtxuxGd2XPovXPVjcSdY3i4rQYisNadjfKy",
-    "tokenName": "Wrapped SUSHI",
+    "tokenName": "Wrapped SUSHI (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
   },
   {
-    "tokenSymbol": "ALEPH",
+    "tokenSymbol": "soALEPH",
     "mintAddress": "CsZ5LZkDS7h9TDKjrbL7VAwQZ9nsRu8vJLhRYfmGaN8K",
-    "tokenName": "Wrapped ALEPH",
+    "tokenName": "Wrapped ALEPH (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/6996a371cd02f516506a8f092eeb29888501447c/blockchains/nuls/assets/NULSd6HgyZkiqLnBzTaeSQfx1TNg2cqbzq51h/logo.png"
   },
   {
-    "tokenSymbol": "SXP",
+    "tokenSymbol": "soSXP",
     "mintAddress": "SF3oTvfWzEP3DTwGSvUXRrGTvr75pdZNnBLAH9bzMuX",
-    "tokenName": "Wrapped SXP",
+    "tokenName": "Wrapped SXP (Sollet)",
     "icon": "https://github.com/trustwallet/assets/raw/b0ab88654fe64848da80d982945e4db06e197d4f/blockchains/ethereum/assets/0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9/logo.png"
   },
   {
-    "tokenSymbol": "HGET",
+    "tokenSymbol": "soHGET",
     "mintAddress": "BtZQfWqDGbk9Wf2rXEiWyQBdBY1etnUUn6zEphvVS7yN",
-    "tokenName": "Wrapped HGET"
+    "tokenName": "Wrapped HGET (Sollet)"
   },
   {
-    "tokenSymbol": "CREAM",
+    "tokenSymbol": "soCREAM",
     "mintAddress": "5Fu5UUgbjpUvdBveb3a1JTNirL8rXtiYeSMWvKjtUNQv",
-    "tokenName": "Wrapped CREAM",
+    "tokenName": "Wrapped CREAM (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/4c82c2a409f18a4dd96a504f967a55a8fe47026d/blockchains/smartchain/assets/0xd4CB328A82bDf5f03eB737f37Fa6B370aef3e888/logo.png"
   },
   {
-    "tokenSymbol": "UBXT",
+    "tokenSymbol": "soUBXT",
     "mintAddress": "873KLxCbz7s9Kc4ZzgYRtNmhfkQrhfyWGZJBmyCbC3ei",
-    "tokenName": "Wrapped UBXT"
+    "tokenName": "Wrapped UBXT (Sollet)"
   },
   {
-    "tokenSymbol": "HNT",
+    "tokenSymbol": "soHNT",
     "mintAddress": "HqB7uswoVg4suaQiDP3wjxob1G5WdZ144zhdStwMCq7e",
-    "tokenName": "Wrapped HNT"
+    "tokenName": "Wrapped HNT (Sollet)"
   },
   {
-    "tokenSymbol": "FRONT",
+    "tokenSymbol": "soFRONT",
     "mintAddress": "9S4t2NEAiJVMvPdRYKVrfJpBafPBLtvbvyS3DecojQHw",
-    "tokenName": "Wrapped FRONT",
+    "tokenName": "Wrapped FRONT (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/6e375e4e5fb0ffe09ed001bae1ef8ca1d6c86034/blockchains/ethereum/assets/0xf8C3527CC04340b208C854E985240c02F7B7793f/logo.png"
   },
   {
-    "tokenSymbol": "AKRO",
+    "tokenSymbol": "soAKRO",
     "mintAddress": "6WNVCuxCGJzNjmMZoKyhZJwvJ5tYpsLyAtagzYASqBoF",
-    "tokenName": "Wrapped AKRO",
+    "tokenName": "Wrapped AKRO (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/878dcab0fab90e6593bcb9b7d941be4915f287dc/blockchains/ethereum/assets/0xb2734a4Cec32C81FDE26B0024Ad3ceB8C9b34037/logo.png"
   },
   {
-    "tokenSymbol": "HXRO",
+    "tokenSymbol": "soHXRO",
     "mintAddress": "DJafV9qemGp7mLMEn5wrfqaFwxsbLgUsGVS16zKRk9kc",
-    "tokenName": "Wrapped HXRO"
+    "tokenName": "Wrapped HXRO (Sollet)"
   },
   {
-    "tokenSymbol": "UNI",
+    "tokenSymbol": "soUNI",
     "mintAddress": "DEhAasscXF4kEGxFgJ3bq4PpVGp5wyUxMRvn6TzGVHaw",
-    "tokenName": "Wrapped UNI",
+    "tokenName": "Wrapped UNI (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/08d734b5e6ec95227dc50efef3a9cdfea4c398a1/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png"
   },
   {
@@ -122,9 +122,9 @@
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x476c5E26a75bd202a9683ffD34359C0CC15be0fF/logo.png"
   },
   {
-    "tokenSymbol": "FTT",
+    "tokenSymbol": "soFTT",
     "mintAddress": "AGFEad2et2ZJif9jaGpdMixQqvW5i81aBdvKe7PHNfz3",
-    "tokenName": "Wrapped FTT",
+    "tokenName": "Wrapped FTT (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/f3ffd0b9ae2165336279ce2f8db1981a55ce30f8/blockchains/ethereum/assets/0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9/logo.png"
   },
   {
@@ -134,43 +134,43 @@
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x476c5E26a75bd202a9683ffD34359C0CC15be0fF/logo.png"
   },
   {
-    "tokenSymbol": "WUSDC",
+    "tokenSymbol": "soUSDC",
     "mintAddress": "BXXkv6z8ykpG1yuvUDPgh732wzVHB69RnB9YgSYh3itW",
-    "tokenName": "Wrapped USDC",
+    "tokenName": "Wrapped USDC (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/f3ffd0b9ae2165336279ce2f8db1981a55ce30f8/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
   },
   {
-    "tokenSymbol": "TOMO",
+    "tokenSymbol": "soTOMO",
     "mintAddress": "GXMvfY2jpQctDqZ9RoU3oWPhufKiCcFEfchvYumtX7jd",
-    "tokenName": "Wrapped TOMO",
+    "tokenName": "Wrapped TOMO (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tomochain/info/logo.png"
   },
   {
-    "tokenSymbol": "KARMA",
+    "tokenSymbol": "soKARMA",
     "mintAddress": "EcqExpGNFBve2i1cMJUTR4bPXj4ZoqmDD2rTkeCcaTFX",
-    "tokenName": "Wrapped KARMA",
+    "tokenName": "Wrapped KARMA (Sollet)",
     "icon": "https://raw.githubusercontent.com/machi-x/assets/152f2ca62611ef23298fac9a8e657386984d2d33/blockchains/ethereum/assets/0xdfe691f37b6264a90ff507eb359c45d55037951c/logo.png"
   },
   {
-    "tokenSymbol": "LUA",
+    "tokenSymbol": "soLUA",
     "mintAddress": "EqWCKXfs3x47uVosDpTRgFniThL9Y8iCztJaapxbEaVX",
-    "tokenName": "Wrapped LUA",
+    "tokenName": "Wrapped LUA (Sollet)",
     "icon": "https://raw.githubusercontent.com/trustwallet/assets/2d2491130e6beda208ba4fc6df028a82a0106ab6/blockchains/ethereum/assets/0xB1f66997A5760428D3a87D68b90BfE0aE64121cC/logo.png"
   },
   {
-    "tokenSymbol": "MATH",
+    "tokenSymbol": "soMATH",
     "mintAddress": "GeDS162t9yGJuLEHPWXXGrb1zwkzinCgRwnT8vHYjKza",
-    "tokenName": "Wrapped MATH"
+    "tokenName": "Wrapped MATH (Sollet)"
   },
   {
-    "tokenSymbol": "KEEP",
+    "tokenSymbol": "soKEEP",
     "mintAddress": "GUohe4DJUA5FKPWo3joiPgsB7yzer7LpDmt1Vhzy3Zht",
-    "tokenName": "Wrapped KEEP"
+    "tokenName": "Wrapped KEEP (Sollet)"
   },
   {
-    "tokenSymbol": "SWAG",
+    "tokenSymbol": "soSWAG",
     "mintAddress": "9F9fNTT6qwjsu4X4yWYKZpsbw5qT7o6yR2i57JF2jagy",
-    "tokenName": "Wrapped SWAG"
+    "tokenName": "Wrapped SWAG (Sollet)"
   },
   {
     "tokenSymbol": "FIDA",
@@ -198,5 +198,119 @@
     "tokenSymbol": "COPE",
     "mintAddress": "3K6rftdAaQYMPunrtNRHgnK2UAtjm2JwyT2oCiTDouYE",
     "tokenName": "COPE"
+  },
+  {
+    "tokenSymbol": "ETH",
+    "mintAddress": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+    "tokenName": "Ether (Wormhole)",
+    "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+  },
+  {
+    "tokenSymbol": "YFI",
+    "mintAddress": "BXZX2JRJFjvKazM1ibeDFxgAngKExb74MRXzXKvgikxX",
+    "tokenName": "YFI (Wormhole)",
+    "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e/logo.png"
+  },
+  {
+    "tokenSymbol": "LINK",
+    "mintAddress": "2wpTofQ8SkACrkZWrZDjXPitYa8AwWgX8AfxdeBRRVLX",
+    "tokenName": "Chainlink (Wormhole)",
+    "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
+  },
+  {
+    "tokenSymbol": "USDTet",
+    "mintAddress": "Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1",
+    "tokenName": "Tether USD (Wormhole from Ethereum)",
+    "icon": "https://raw.githubusercontent.com/trustwallet/assets/f3ffd0b9ae2165336279ce2f8db1981a55ce30f8/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png"
+  },
+  {
+    "tokenSymbol": "SUSHI",
+    "mintAddress": "ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj",
+    "tokenName": "SUSHI (Wormhole)",
+    "icon": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png"
+  },
+  {
+    "mintAddress": "3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x",
+    "tokenName": "Aleph.im (Wormhole)",
+    "tokenSymbol": "ALEPH",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x/logo.png"
+  },
+  {
+    "mintAddress": "3CyiEDRehaGufzkpXJitCP5tvh7cNhRqd9rPBxZrgK5z",
+    "tokenName": "Swipe (Wormhole)",
+    "tokenSymbol": "SXP",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3CyiEDRehaGufzkpXJitCP5tvh7cNhRqd9rPBxZrgK5z/logo.png"
+  },
+  {
+    "mintAddress": "2ueY1bLcPHfuFzEJq7yN1V2Wrpu8nkun9xG2TVCE1mhD",
+    "tokenName": "Hedget (Wormhole)",
+    "tokenSymbol": "HGET",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2ueY1bLcPHfuFzEJq7yN1V2Wrpu8nkun9xG2TVCE1mhD/logo.png"
+  },
+  {
+    "mintAddress": "HihxL2iM6L6P1oqoSeiixdJ3PhPYNxvSKH9A2dDqLVDH",
+    "tokenName": "Cream (Wormhole)",
+    "tokenSymbol": "CREAM",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HihxL2iM6L6P1oqoSeiixdJ3PhPYNxvSKH9A2dDqLVDH/logo.png"
+  },
+  {
+    "mintAddress": "FTtXEUosNn6EKG2SQtfbGuYB4rBttreQQcoWn1YDsuTq",
+    "tokenName": "UpBots (Wormhole)",
+    "tokenSymbol": "UBXT",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FTtXEUosNn6EKG2SQtfbGuYB4rBttreQQcoWn1YDsuTq/logo.png"
+  },
+  {
+    "mintAddress": "A9ik2NrpKRRG2snyTjofZQcTuav9yH3mNVHLsLiDQmYt",
+    "tokenName": "Frontier Token (Wormhole)",
+    "tokenSymbol": "FRONT",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9ik2NrpKRRG2snyTjofZQcTuav9yH3mNVHLsLiDQmYt/logo.png"
+  },
+  {
+    "mintAddress": "12uHjozDVgyGWeLqQ8DMCRbig8amW5VmvZu3FdMMdcaG",
+    "tokenName": "Akropolis (Wormhole)",
+    "tokenSymbol": "AKRO",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/G3h8NZgJozk9crme2me6sKDJuSQ12mNCtvC9NbSWqGuk/logo.png"
+  },
+  {
+    "mintAddress": "HxhWkVpk5NS4Ltg5nij2G671CKXFRKPK8vy271Ub4uEK",
+    "tokenName": "Hxro (Wormhole)",
+    "tokenSymbol": "HXRO",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HxhWkVpk5NS4Ltg5nij2G671CKXFRKPK8vy271Ub4uEK/logo.png"
+  },
+  {
+    "mintAddress": "8FU95xFJhUUkyyCLU13HSzDLs7oC4QZdXQHL6SCeab36",
+    "tokenName": "Uniswap (Wormhole)",
+    "tokenSymbol": "UNI",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8FU95xFJhUUkyyCLU13HSzDLs7oC4QZdXQHL6SCeab36/logo.png"
+  },
+  {
+    "mintAddress": "EzfgjvkSwthhgHaceR3LnKXUoRkP6NUhfghdaHAj1tUv",
+    "tokenName": "FTX Token (Wormhole)",
+    "tokenSymbol": "FTT",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EzfgjvkSwthhgHaceR3LnKXUoRkP6NUhfghdaHAj1tUv/logo.png"
+  },
+  {
+    "mintAddress": "5Wc4U1ZoQRzF4tPdqKQzBwRSjYe8vEf3EvZMuXgtKUW6",
+    "tokenName": "LuaToken (Wormhole)",
+    "tokenSymbol": "LUA",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5Wc4U1ZoQRzF4tPdqKQzBwRSjYe8vEf3EvZMuXgtKUW6/logo.png"
+  },
+  {
+    "mintAddress": "CaGa7pddFXS65Gznqwp42kBhkJQdceoFVT7AQYo8Jr8Q",
+    "tokenName": "MATH Token (Wormhole)",
+    "tokenSymbol": "MATH",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CaGa7pddFXS65Gznqwp42kBhkJQdceoFVT7AQYo8Jr8Q/logo.png"
+  },
+  {
+    "mintAddress": "64L6o4G2H7Ln1vN7AHZsUMW4pbFciHyuwn4wUdSbcFxh",
+    "tokenName": "Keep Network (Wormhole)",
+    "tokenSymbol": "KEEP",
+    "icon": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg"
+  },
+  {
+    "mintAddress": "5hcdG6NjQwiNhVa9bcyaaDsCyA1muPQ6WRzQwHfgeeKo",
+    "tokenName": "Swag Token (Wormhole)",
+    "tokenSymbol": "SWAG",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5hcdG6NjQwiNhVa9bcyaaDsCyA1muPQ6WRzQwHfgeeKo/logo.png"
   }
 ]

--- a/packages/tokens/src/mainnet-beta.json
+++ b/packages/tokens/src/mainnet-beta.json
@@ -312,5 +312,89 @@
     "tokenName": "Swag Token (Wormhole)",
     "tokenSymbol": "SWAG",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5hcdG6NjQwiNhVa9bcyaaDsCyA1muPQ6WRzQwHfgeeKo/logo.png"
+  },
+  {
+    "mintAddress": "KgV1GvrHQmRBY8sHQQeUKwTm2r2h8t4C8qt12Cw1HVE",
+    "tokenName": "AVAX (Wormhole)",
+    "tokenSymbol": "AVAX",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/KgV1GvrHQmRBY8sHQQeUKwTm2r2h8t4C8qt12Cw1HVE/logo.png"
+  },
+  {
+    "mintAddress": "HysWcbHiYY9888pHbaqhwLYZQeZrcQMXKQWRqS7zcPK5",
+    "tokenName": "Axie Infinity Shard (Wormhole from Ethereum)",
+    "tokenSymbol": "AXSet",
+    "icon": "https://cloudflare-ipfs.com/ipfs/QmVUzbiJP2xm2rH69Y42rmTxD8MZxEpGmvdfVKe551zZcR/"
+  },
+  {
+    "mintAddress": "9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa",
+    "tokenName": "Binance Coin (Wormhole)",
+    "tokenSymbol": "BNB",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa/logo.png"
+  },
+  {
+    "mintAddress": "AuGz22orMknxQHTVGwAu7e3dJikTJKgcjFwMNDikEKmF",
+    "tokenName": "Gala (Wormhole)",
+    "tokenSymbol": "GALA",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AuGz22orMknxQHTVGwAu7e3dJikTJKgcjFwMNDikEKmF/logo.png"
+  },
+  {
+    "mintAddress": "F6v4wfAdJB8D8p77bMXZgYt8TDKsYxLYxH5AFhUkYx9W",
+    "tokenName": "LUNA (Wormhole)",
+    "tokenSymbol": "LUNA",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/F6v4wfAdJB8D8p77bMXZgYt8TDKsYxLYxH5AFhUkYx9W/logo.png"
+  },
+  {
+    "mintAddress": "Gz7VkD4MacbEB6yC5XD3HcumEiYx2EtDYYrfikGsvopG",
+    "tokenName": "Matic (Wormhole from Polygon)",
+    "tokenSymbol": "MATICpo",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/C7NNPWuZCNjZBfW5p6JvGsR8pUdsRpEdP1ZAhnoDwj7h/logo.png"
+  },
+  {
+    "mintAddress": "S3SQfD6RheMXQ3EEYn1Z5sJsbtwfXdt7tSAVXPQFtYo",
+    "tokenName": "ROSE (Wormhole)",
+    "tokenSymbol": "ROSE",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/S3SQfD6RheMXQ3EEYn1Z5sJsbtwfXdt7tSAVXPQFtYo/logo.png"
+  },
+  {
+    "mintAddress": "49c7WuCZkQgc3M4qH8WuEUNXfgwupZf1xqWkDQ7gjRGt",
+    "tokenName": "Sandbox (Wormhole)",
+    "tokenSymbol": "SAND",
+    "icon": "https://gemini.com/images/currencies/icons/default/sand.svg"
+  },
+  {
+    "mintAddress": "CiKu4eHsVrc1eueVQeHn7qhXTcVu95gSQmBpX4utjL9z",
+    "tokenName": "SHIBA INU (Wormhole)",
+    "tokenSymbol": "SHIB",
+    "icon": "https://cloudflare-ipfs.com/ipfs/QmU8BZDCVQuVGyX25ApGGkRy2KKG2QDqe4UhKrxYbNMjwr/"
+  },
+  {
+    "mintAddress": "9vMJfxuKxXBoEa7rM12mYLMwTacLMLDJqHozw96WQL8i",
+    "tokenName": "UST (Wormhole)",
+    "tokenSymbol": "UST",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9vMJfxuKxXBoEa7rM12mYLMwTacLMLDJqHozw96WQL8i/logo.png"
+  },
+  {
+    "mintAddress": "EdAhkbj5nF9sRM7XN7ewuW8C9XEUMs8P7cnoQ57SYE96",
+    "tokenName": "FABRIC",
+    "tokenSymbol": "FAB",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EdAhkbj5nF9sRM7XN7ewuW8C9XEUMs8P7cnoQ57SYE96/logo.png"
+  },
+  {
+    "mintAddress": "JET6zMJWkCN9tpRT2v2jfAmm5VnQFDpUBCyaKojmGtz",
+    "tokenName": "Jet Protocol",
+    "tokenSymbol": "JET",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/JET6zMJWkCN9tpRT2v2jfAmm5VnQFDpUBCyaKojmGtz/logo.png"
+  },
+  {
+    "mintAddress": "5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm",
+    "tokenName": "Socean staked SOL",
+    "tokenSymbol": "scnSOL",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm/logo.png"
+  },
+  {
+    "mintAddress": "7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj",
+    "tokenName": "Lido Staked SOL",
+    "tokenSymbol": "stSOL",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj/logo.png"
   }
 ]


### PR DESCRIPTION
in both mainnet-beta.json and markets.json:
* rename sollet-wrapped ETH to soETH (etc)
* add wormhole-wrapped ETH as ETH

soon we might want to remove the sollet-based markets, but i didn't want to do that yet