### PR TITLE
getL2 use add instead of iadd

### DIFF
--- a/packages/serum/src/market.ts
+++ b/packages/serum/src/market.ts
@@ -1496,7 +1496,7 @@ export class Orderbook {
     for (const { key, quantity } of this.slab.items(descending)) {
       const price = getPriceFromKey(key);
       if (levels.length > 0 && levels[levels.length - 1][0].eq(price)) {
-        levels[levels.length - 1][1].iadd(quantity);
+        levels[levels.length - 1][1] = levels[levels.length - 1][1].add(quantity);
       } else if (levels.length === depth) {
         break;
       } else {


### PR DESCRIPTION
`getL2`'s usage of `iadd` mutates state, which can cause unwanted side effects. Switching to `add` so the BN isn't modified in place seems to resolve