### PR TITLE
remove package.json `source` & source maps from serum package

### DIFF
--- a/packages/serum/package.json
+++ b/packages/serum/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "repository": "project-serum/serum-ts",
   "main": "lib/index.js",
-  "source": "src/index.js",
   "types": "lib/index.d.ts",
   "engines": {
     "node": ">=10"

--- a/packages/serum/tsconfig.json
+++ b/packages/serum/tsconfig.json
@@ -7,8 +7,7 @@
     "declaration": true,
     "declarationMap": true,
     "noImplicitAny": false,
-    "resolveJsonModule": true,
-    "sourceMap": true
+    "resolveJsonModule": true
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/**/*.test.js", "node_modules", "**/node_modules"]


### PR DESCRIPTION
the `src/` lib isn't included in the @project-serum/serum package on npm

but the `source` field is pointing to it and source maps are generated in the typescript output

this broken link from [package.json]source > [dir]src, is causing [parcel](https://parceljs.org/) to error-out when building a project that has @project-serum/serum as a dependency

to fix I think you could either remove `source` field in package.json and (optionally) source maps from the build, or include the src directory in the package archive on npm


similar discussion: https://github.com/googleapis/google-cloud-node/issues/2867