### PR TITLE
fix rustEnum missing params defaultLayout

### DIFF
--- a/packages/borsh/src/index.ts
+++ b/packages/borsh/src/index.ts
@@ -262,7 +262,7 @@ export function rustEnum<T>(
   property?: string,
   discriminant?: Layout<any>,
 ): EnumLayout<T> {
-  const unionLayout = union(discriminant ?? u8(), property);
+  const unionLayout = union(discriminant ?? u8(), undefined, property);
   variants.forEach((variant, index) =>
     unionLayout.addVariant(index, variant, variant.property),
   );


### PR DESCRIPTION
@projectserum/borsh rustEnum is missing params defaultLayout