### PR TITLE
Make 256-bit integers available on Borsh encoding

### DIFF
--- a/packages/borsh/src/index.ts
+++ b/packages/borsh/src/index.ts
@@ -81,6 +81,14 @@ export function i128(property?: string): Layout<BN> {
   return new BNLayout(16, true, property);
 }
 
+export function u256(property?: string): Layout<BN> {
+  return new BNLayout(32, false, property);
+}
+
+export function i256(property?: string): Layout<BN> {
+  return new BNLayout(32, true, property);
+}
+
 class WrappedLayout<T, U> extends LayoutCls<U> {
   layout: Layout<T>;
   decoder: (data: T) => U;


### PR DESCRIPTION
The Solang Solidity compiler is adding Anchor compatibly for Solidity contracts on Solana. Our goal is to have developers write their contracts in Solidity and use Anchor for the client side code. Solidity supports 256-bit integers and we aim to make them available on Anchor.

This PR ensures we can encode and decode them from a buffer when making CPI calls.